### PR TITLE
Atualiza versão de actions notificar-lista-de-emails.yaml

### DIFF
--- a/.github/workflows/notificar-lista-de-emails.yaml
+++ b/.github/workflows/notificar-lista-de-emails.yaml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Python 3.11
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.11
       - name: Instala apyb-bot


### PR DESCRIPTION
Resolve a mensagem:

> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/setup-python@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/